### PR TITLE
Updates documentation

### DIFF
--- a/documentation/API.md
+++ b/documentation/API.md
@@ -3,7 +3,7 @@
 The base MissingMaps API endpoint is located at http://osmstats.redcross.org/
 
 ### / (root) endpoint
-The root endpoint serves select total statistics for all tracked users, including km of roads, number of building edits, number of total edits, number of changesets, and the timestamp of the latest edit. A successful response is formatted as such:
+The `root` endpoint serves select total statistics for all tracked users, including km of roads, number of building edits, number of total edits, number of changesets, and the timestamp of the latest edit. This endpoint is used to populate the aggregate statistics sections of Missing Maps' [main landing page](http://www.missingmaps.org/) as well as its partner pages. A successful response is formatted as such:
 ```js
 [
    {
@@ -17,18 +17,18 @@ The root endpoint serves select total statistics for all tracked users, includin
 ]
 ```
 ### /users endpoint
-The users endpoint of the API returns an array of objects representing all users in the system, with attributes for their numerical id and username. A successful response is formatted as such:
+The `users` endpoint of the API returns an array of objects representing all users in the system, with attributes for their numerical id and username. This endpoint is used to drive the username search feature of Missing Maps' user page portal. A successful response is formatted as such:
 ```js
 [
    {
       "id": 3656995,
       "name": "Christine Karatnytsky"
    },
-
+   ...
 ]
 ```
 ### /users/{user_id#} endpoint
-The users/{user_id#} endpoint returns an object representing all the information that is known about a particular user. This includes:
+The `users/{user_id#}` endpoint returns an object representing all the information that is known about a particular user. This includes:
 
 - The total number of new features and modifications made to buildings, waterways, roads, and pois, their total number of gps traces, their total number of josm edits, and the kilometers of roads and waterways they have contributed.
 - A hashtags object containing the hashtags the user has contributed to along with the number of times they have contributed to each.
@@ -39,7 +39,7 @@ The users/{user_id#} endpoint returns an object representing all the information
 - A geo_extent object, containing a geojson feature representing the buffered area of the user's changeset submissions.
 - The user's name and id.
 
-A successful response from the users/{user_id#} endpoint is formatted as such:
+This endpoint is used to populate each user's profile within Missing Maps' user page portal. A successful response from the `users/{user_id#}` endpoint is formatted as such:
 ```js
 {
    "id": 3656995,
@@ -62,7 +62,6 @@ A successful response from the users/{user_id#} endpoint is formatted as such:
    "total_gps_trace_updated_from_osm": "2016-02-25T00:47:47.308Z",
    "total_road_count_add": "0.00000000000000000000",
    "total_road_count_mod": "0.00000000000000000000",
-
    "badges":[ {
       "created_at":"2016-02-27T19:50:10.442Z",
       "id":34,
@@ -71,8 +70,7 @@ A successful response from the users/{user_id#} endpoint is formatted as such:
       "name":"Awesome JOSM",
       "_pivot_user_id":129531,
       "_pivot_badge_id":34
-   },
-
+   }, ...
    ],
    "changeset_count": "44",
    "latest": {
@@ -98,7 +96,7 @@ A successful response from the users/{user_id#} endpoint is formatted as such:
             "code": "COD",
             "created_at": "2016-02-14T19:02:44.124Z"
          },
-
+         ...
       ],
       "hashtags": [
          {
@@ -106,27 +104,27 @@ A successful response from the users/{user_id#} endpoint is formatted as such:
             "hashtag": "missingmaps",
             "created_at": "2016-02-14T19:31:34.758Z"
          },
-
+         ...
       ]
    },
    "edit_times": [
       "2016-02-24T23:15:58.000Z",
-
+      ...
    ],
    "country_count": 1,
    "country_list": {
       "Democratic Republic of the Congo": 44,
-
+      ...
    },
    "hashtags": {
       "missingmaps": 44,
-
+      ...
    }
 }
 ```
 ### /hashtags endpoint
-The hashtags endpoint returns an object containing a hashtags array and a trending array.
-The hashtags array contains every hashtag known to the system, and the trending array contains between 0 and 5 of the most trending hashtags, depending on how many hashtags are calculated as trending at a given time. A successful response from the hashtags endpoint is formatted as such:
+The `hashtags` endpoint returns an object containing a hashtags array and a trending array.
+The hashtags array contains every hashtag known to the system, and the trending array contains between 0 and 5 of the most trending hashtags, depending on how many hashtags are calculated as trending at a given time. This endpoint is used as a reference to hashtags in the system, for further investigation using the `/hashtags/{hashtag-name}` endpoint, and the trending property is employed by Missing Maps' leaderboard pages to detect recently-active projects. A successful response from the hashtags endpoint is formatted as such:
 ```js
 {
    "hashtags": [
@@ -138,13 +136,12 @@ The hashtags array contains every hashtag known to the system, and the trending 
    "trending": [
       "missingmaps",
       "hotosm-project-724",
-
-
+      ...
    ]
 }
 ```
 ### /hashtags/{hashtag-name} endpoint
-The hashtags/hashtag-name endpoint returns the total number of road, building, waterway, and poi edits for a hashtag, an array of users who have edited that hashtag and their total edits, and an array of timestamps with the total number of road, buildings, waterways or POIs submitted at that time. A successful response is formatted as such:
+The `hashtags/hashtag-name` endpoint returns the total number of road, building, waterway, and poi edits for a hashtag, an array of users who have edited that hashtag and their total edits, and an array of timestamps with the total number of road, buildings, waterways or POIs submitted at that time. This endpoint is used to drive the per-user statistics shown in Missing Maps' leaderboard pages. A successful response is formatted as such:
 ```js
 {
    "total": {
@@ -158,7 +155,7 @@ The hashtags/hashtag-name endpoint returns the total number of road, building, w
          "name": "akdegraff",
          "total": 46
       },
-
+      ...
    },
    "times": {
       "Sun Feb 14 2016 15:55:41 GMT-0500 (EST)": {
@@ -167,24 +164,46 @@ The hashtags/hashtag-name endpoint returns the total number of road, building, w
          "waterways": 0,
          "pois": 0
       },
-
+      ...
    }
 }
 ```
-### /hashtags/{hashtag-name}/users endpoint
-The /hashtags/{hashtag-name}/users endpoint returns an array of each user who has contributed under a given hashtag. Within their entry, their name, id, total number of edits, total road edits, and total building edits is displayed. A successful response is formatted as such:
+### /group-summaries/{hashtag-name-1, hashtag-name-2, ...} endpoint
+The `/group-summaries/{hashtag-name-1, hashtag-name-2, ...}` endpoint summarizes contribution statistics (counts and number of kilometers edited or modified for roads, buildings, waterways, and points of interest) for an arbitrary number of hashtag names. It takes a comma-separated list of hashtag names and returns an object with keys representing each input hashtag, to which values summarizing the edits across every changeset associated with that hashtag are attached. This endpoint is used to populate the team activity section of Missing Maps' partner pages. A successful response is formatted as such:
 ```js
-[
-   {
-      "name": "Proenn",
-      "user_id": 3655790,
-      "edits": 12,
-      "roads": 0,
-      "buildings": 237,
-      "created_at":"2016-03-01T20:27:04.000Z"
-   },
-
-]
+{
+  "redcross": {
+    "road_count_add": "22095.00000000000000000000",
+    "road_count_mod": "12020.00000000000000000000",
+    "building_count_add": "551403.00000000000000000000",
+    "building_count_mod": "13080.00000000000000000000",
+    "waterway_count_add": "2395.00000000000000000000",
+    "poi_count_add": "753.00000000000000000000",
+    "road_km_add": "9687.19743822583132324000",
+    "road_km_mod": "26034.58731152841223024050",
+    "waterway_km_add": "1508.31848967040574971000"
+  },
+  "missingmaps": {
+    "road_count_add": "149582.00000000000000000000",
+    ...
+  }, ...
+}
+```
+### /top-users/{hashtag-name} endpoint
+The `/top-users/{hashtag-name}` endpoint takes a hashtag name and returns an object listing the top five users associated with that hashtag, by total number of contributions. For each user, the returned object includes a summary of all edits (including additions and modifications) across all categories, a count of building and road additions and modifications, the number of road kilometers edited or modified, and the user's numerical ID. This endpoint is used to populate the user activity section of Missing Maps' partner pages. A successful response is formatted as such:
+```js
+{
+  "dmgroom_ct": {
+    "all_edits": "11900.00000000000000000000",
+    "buildings": "11662.00000000000000000000",
+    "roads": "172.00000000000000000000",
+    "road_kms": "252.69297739511491667000",
+    "user_number": 437598
+  },
+    "PaulKnight": {
+    ...
+  }, ...
+}
 ```
 ### /hashtags/{hashtag-name}/map endpoint
-The /hashtags/{hashtag-name}/map endpoint returns a GeoJSON feature collection of the past 100 edits made for a given hashtag.
+The `/hashtags/{hashtag-name}/map` endpoint returns a GeoJSON feature collection of the past 100 edits made for a given hashtag.


### PR DESCRIPTION
Updates documentation to connect to Missing Maps' site and to describe the new top-users and group-summaries endpoints of the OSM-Stats API
