### PR TITLE
Bump versions of updated components

### DIFF
--- a/deploy/osm-stats-api/Dockerfile
+++ b/deploy/osm-stats-api/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:4.2
 
-ENV API_VERSION 0.3.3
+ENV API_VERSION 0.4.0
 
 RUN curl -sSL https://github.com/AmericanRedCross/osm-stats-api/archive/${API_VERSION}.tar.gz \
   | tar -v -C /usr/src -xz

--- a/deploy/planet-stream/docker-compose.yml
+++ b/deploy/planet-stream/docker-compose.yml
@@ -1,0 +1,11 @@
+redis:
+  image: redis
+  ports:
+    - '6379'
+app:
+  build: .
+  environment:
+    - LOG_LEVEL='debug'
+    - PS_OUTPUT_DEBUG='true'
+  links:
+    - redis

--- a/deploy/planet-stream/package.json
+++ b/deploy/planet-stream/package.json
@@ -15,7 +15,7 @@
     "dotenv": "^2.0.0",
     "ioredis": "^1.15.0",
     "log": "^1.4.0",
-    "planet-stream": "^0.3.1",
+    "planet-stream": "^0.3.2",
     "ramda": "^0.19.1",
     "request-promise": "^2.0.0",
     "shortid": "^2.2.4",


### PR DESCRIPTION
Bumps the versions of planet-stream to 0.3.2 and osm-stats-api to 0.4.0.
This fixes a few bugs and adds new functionality to the API (visit the
repos of those components for the changelog).

Additionally adds a compose file for running planet-stream standalone
for testing.

cc @matthewhanson 
