### PR TITLE
Increase housekeeping container size

### DIFF
--- a/deployment/osm-stats.tf
+++ b/deployment/osm-stats.tf
@@ -96,8 +96,8 @@ resource "azurerm_container_group" "osm-stats" {
   container {
     name = "housekeeping"
     image = "quay.io/americanredcross/osm-stats-workers"
-    cpu = "0.5"
-    memory = "0.5"
+    cpu = "1"
+    memory = "2"
     ports {
       port = 8081 # unbound but required
     }


### PR DESCRIPTION
cc @mojodna 

There are still delays in generating user data, especially right around when there is a mapathon happening. We think increasing the housekeeping container will mitigate that.

I have figured out how to get terraform connected to azure so if you approve and merge this PR I can run the terraform apply updates myself.